### PR TITLE
PROTOCOL: Update to gameplay protocol extensions.

### DIFF
--- a/pkg/qtv/downstream_client_commands.go
+++ b/pkg/qtv/downstream_client_commands.go
@@ -245,7 +245,7 @@ func (ds *dStream) soundListClientCmd(tr *tokenizerResult) (err error) {
 		return ds.setState(dsNeedInitialData)
 	}
 
-	if err := us.qp.sendList(ds, us.qp.soundList[:], svc_soundlist); err != nil {
+	if err := us.qp.sendList(ds, us.qp.soundList[:], svc_soundlist, svc_fte_soundlistshort_UNUSED); err != nil {
 		return err
 	}
 
@@ -271,7 +271,7 @@ func (ds *dStream) modelListClientCmd(tr *tokenizerResult) (err error) {
 		return ds.setState(dsNeedInitialData)
 	}
 
-	if err := us.qp.sendList(ds, us.qp.modelList[:], svc_modellist); err != nil {
+	if err := us.qp.sendList(ds, us.qp.modelList[:], svc_modellist, svc_fte_modellistshort); err != nil {
 		return err
 	}
 

--- a/pkg/qtv/upstream_mvd.go
+++ b/pkg/qtv/upstream_mvd.go
@@ -491,10 +491,10 @@ func (us *uStream) sendInitialMVDData_1_0(ds *dStream) (err error) {
 	if err := us.qp.sendServerData(ds); err != nil {
 		return err
 	}
-	if err := us.qp.sendList(ds, us.qp.soundList[:], svc_soundlist); err != nil {
+	if err := us.qp.sendList(ds, us.qp.soundList[:], svc_soundlist, svc_fte_soundlistshort_UNUSED); err != nil {
 		return err
 	}
-	if err := us.qp.sendList(ds, us.qp.modelList[:], svc_modellist); err != nil {
+	if err := us.qp.sendList(ds, us.qp.modelList[:], svc_modellist, svc_fte_modellistshort); err != nil {
 		return err
 	}
 	if err := us.qp.sendPreSpawn(ds); err != nil {


### PR DESCRIPTION
Aligns QTV to currently enabled gameplay extensions:

* PEXT_SPAWNSTATIC2 - Delta spawns for extended attributes
  * svc_fte_spawnstatic2
  * svc_fte_spawnbaseline2
* PEXT_ENTITYDBL - Up to 1024 entities
* PEXT_ENTITYDBL2 - Up to 2048 entities
* PEXT_MODELDBL - Up to uint16 model indices
  * svc_fte_modellistshort
* PEXT_TRANS - 1 byte alpha field on entities
* PEXT_COLOURMOD - 3 byte colourmod on entities

Watching a stream of a modern mvdsv will require a modern client.